### PR TITLE
Adding M-Lab testbed configuration details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,40 @@
 # ndt-e2e-ansible
 Ansible playbooks for NDT E2E Testing system
 
+## Overview
+
+These playbooks automate end-to-end testing of NDT, including:
+
+* Provisioning nodes for NDT end-to-end testing
+* Executing NDT end-to-end tests
+* Gathering test results and copying them back to the control machine
+
+Configurations include:
+
+* Control Machine - prepares the control machine to facilitate management of
+  nodes in the NDT testbed
+* Testbed Nodes - provisions nodes in the testbed for end-to-end testing.
+
+Test execution options include:
+
+* Run NDT using single client or multiple clients.
+* Run a single iteration for each configuration or N iterations.
+* Run all NDT tests that fit given client conditions (e.g. OS type, browser
+  type).
+
 ## Pre-Requisites
 
 The user must:
 
-* Have Ansible installed on their machine (preferably the [latest source version](http://docs.ansible.com/ansible/intro_installation.html#running-from-source)).
+* Have Ansible installed on their control machine (preferably the
+[latest source version](http://docs.ansible.com/ansible/intro_installation.html#running-from-source)).
 * Have access to the M-Lab testbed
 
 ## Getting Started
 
-### Configuring the control node
+### Configuring the control machine
 
-To configure the control node to manage the machines in the testbed, run the
+To configure the control machine to manage the machines in the testbed, run the
 following command:
 
 ```bash
@@ -42,8 +64,8 @@ times on the same node is safe.
 The following are examples of ways to perform tests and collect results using
 the test execution playbook.
 
-In all examples, the test results will appear on the control node in the folder
-specified by the `local_archive_dir` variable.
+In all examples, the test results will appear on the control machine in the
+folder specified by the `local_archive_dir` variable.
 
 ##### Run a single test iteration under all configurations
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ The user must:
 
 ### Configuring the control machine
 
-To configure the control machine to manage the machines in the testbed, run the
-following command:
+The "control machine" in Ansible terms is the machine from which the operator
+runs Ansible commands and executes playbooks. To configure your machine to be a
+control machine for the NDT E2E testing playbooks so that you can manage the
+M-Lab NDT testbed, run the following command from your local machine:
 
 ```bash
 ansible-playbook configure_control.yml

--- a/README.md
+++ b/README.md
@@ -1,2 +1,99 @@
 # ndt-e2e-ansible
 Ansible playbooks for NDT E2E Testing system
+
+## Pre-Requisites
+
+The user must:
+
+* Have Ansible installed on their machine (preferably the [latest source version](http://docs.ansible.com/ansible/intro_installation.html#running-from-source)).
+* Have access to the M-Lab testbed
+
+## Getting Started
+
+### Configuring the control node
+
+To configure the control node to manage the machines in the testbed, run the
+following command:
+
+```bash
+ansible-playbook configure_control.yml
+```
+
+### Provisioning client worker nodes
+
+To provision the testbed nodes so that they can perform automated NDT E2E
+testing, run the following command:
+
+```bash
+ansible-playbook prepare.yml
+```
+
+To provision a single testbed node (e.g. `mlab-linux-mini`), run the following:
+
+```bash
+ansible-playbook prepare.yml -l mlab-linux-mini
+```
+
+The provisioning is idempotent, so running the provisioning script multiple
+times on the same node is safe.
+
+### Performing E2E tests
+
+The following are examples of ways to perform tests and collect results using
+the test execution playbook.
+
+In all examples, the test results will appear on the control node in the folder
+specified by the `local_archive_dir` variable.
+
+##### Run a single test iteration under all configurations
+
+This runs a single NDT E2E test on all remote nodes for with each supported test
+type:
+
+```bash
+ansible-playbook run.yml
+```
+
+##### Run a single test on a single node
+
+```bash
+ansible-playbook run.yml -l mlab-linux-mini
+```
+
+##### Run a single test on all OS X nodes
+
+```bash
+ansible-playbook run.yml -l osx
+```
+
+##### Run only the NDT HTML5 reference client on a single node
+
+This performs tests on a single node using only the NDT HTML5 reference client:
+
+```bash
+ansible-playbook run.yml -l mlab-linux-mini --tags "facts,html5,gather"
+```
+
+##### Perform 50 test iterations on a single node
+
+```bash
+ansible-playbook run.yml \
+  -l mlab-linux-mini \
+  --extra-vars "iterations=50"
+```
+
+##### Perform 50 test iterations on a single node with a specific configuration
+
+This is a more advanced example. It runs:
+
+* 50 test iterations
+* using only the NDT HTML5 reference client
+* only under the Chrome browser
+* on the mlab-mac-capitan remote node
+
+```bash
+ansible-playbook run.yml \
+  -l mlab-mac-capitan \
+  --extra-vars "supported_browsers=chrome iterations=50" \
+  --tags "facts,html5,gather"
+```

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+hostfile = hosts
+# Disable host key checking. The host keys may change as machines are wiped and
+# reinstalled. The risk of someone attempting to spoof an M-Lab control node is
+# very low and the impact would be inconsequential.
+host_key_checking = False

--- a/configure_control.yml
+++ b/configure_control.yml
@@ -1,0 +1,23 @@
+---
+# vim:ft=ansible:
+
+- name: Configure control nodes to access the testbed
+  hosts: localhost
+  become: True
+  become_method: sudo
+  become_user: root
+  tasks:
+    - name: Add testbed nodes to hosts file
+      blockinfile:
+        dest: /etc/hosts
+        marker: "# {mark} ANSIBLE MANAGED BLOCK - M-Lab Testbed"
+        block: |
+          172.16.1.27        mlab-linux-mini
+          172.16.1.28        mlab-mac-mountainlion
+          172.16.1.29        mlab-mac-yosemite
+          172.16.1.30        mlab-mac-capitan
+          172.16.1.31        mlab-wdoze7
+          172.16.1.32        mlab-wdoze8
+          172.16.1.33        mlab-wdoze10
+          172.16.1.34        mlab-testmaster
+          172.16.1.35        mlabmeddlebox

--- a/hosts
+++ b/hosts
@@ -1,0 +1,33 @@
+[windows]
+mlab-wdoze10
+# Not yet in active use.
+#mlab-wdoze8
+#mlab-wdoze7
+
+[windows:vars]
+ansible_connection=winrm
+ansible_port=5986
+# Disable cert validation. The certificates may change as the machines are wiped
+# and reinstalled. The risk of someone attempting to spoof an M-Lab control node
+# is very low and the impact would be inconsequential.
+ansible_winrm_server_cert_validation=ignore
+
+[linux]
+mlab-linux-mini
+
+[osx]
+mlab-mac-capitan
+# Not yet in active use.
+#mlab-mac-yosemite
+#mlab-mac-mountainlion
+
+[all:vars]
+http_proxy=http://172.16.1.1:8080
+ndt_server_fqdn=ndt.iupui.mlab2.iad0t.measurement-lab.org
+ndt_server_url="{{ ndt_server_fqdn }}:7123/"
+# Note: The username and password are *not* secret and are safe to publish. The
+# credentials are not useful unless the user already has access to the testbed,
+# and there are no trust boundaries within the testbed itself.
+ansible_user=mlab
+ansible_password=mlab
+ansible_become_password={{ ansible_password }}


### PR DESCRIPTION
Adding configuration details for the M-Lab testbed.
Adds a README that documents how to use the ansible playbooks to manage tasks
in the testbed.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-ansible/8)

<!-- Reviewable:end -->
