### PR TITLE
Updating to latest banjo replay

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -3,7 +3,7 @@ local_http_replay_dir: http_replays
 
 # HTTP replay file for Banjo client (note that this file is not in this git
 # repo and must be generated or copied by an alternative means).
-http_replay_file: banjo-2016-04-25.replay
+http_replay_file: banjo-2016-05-10.replay
 
 # Git URL for NDT E2E Client Worker.
 ndt_e2e_client_git: https://github.com/m-lab/ndt-e2e-clientworker.git


### PR DESCRIPTION
This updates the HTTP replay for the banjo client to the latest version
(2016-05-10). Note that the HTTP replay file itself is distributed outside
of this repository.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-ansible/10)

<!-- Reviewable:end -->
