### PR TITLE
Updating Windows hostnames to account for name change

### DIFF
--- a/configure_control.yml
+++ b/configure_control.yml
@@ -16,8 +16,8 @@
           172.16.1.28        mlab-mac-mountainlion
           172.16.1.29        mlab-mac-yosemite
           172.16.1.30        mlab-mac-capitan
-          172.16.1.31        mlab-wdoze7
-          172.16.1.32        mlab-wdoze8
-          172.16.1.33        mlab-wdoze10
+          172.16.1.31        mlab-win7
+          172.16.1.32        mlab-win8
+          172.16.1.33        mlab-win10
           172.16.1.34        mlab-testmaster
           172.16.1.35        mlabmeddlebox

--- a/hosts
+++ b/hosts
@@ -1,8 +1,8 @@
 [windows]
-mlab-wdoze10
+mlab-win10
 # Not yet in active use.
-#mlab-wdoze8
-#mlab-wdoze7
+#mlab-win8
+#mlab-win7
 
 [windows:vars]
 ansible_connection=winrm


### PR DESCRIPTION
We've updated the Windows hosts in the testbed to use more standard names. This updates our playbooks to match.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-ansible/14)

<!-- Reviewable:end -->
