### PR TITLE
Fixes the replay file copy task

### DIFF
--- a/prepare.yml
+++ b/prepare.yml
@@ -320,6 +320,12 @@
       tags: ndt-e2e
       pip: name=mitmproxy
 
+    - name: create HTTP replay directory
+      tags: ndt-e2e
+      file: path={{ http_replay_dir }}
+            state=directory
+            owner={{ ansible_user }}
+
     - name: copy HTTP replay file
       tags: ndt-e2e
       copy: src={{ local_http_replay_dir }}/{{ http_replay_file }}
@@ -452,8 +458,6 @@
            executable=/usr/local/bin/pip
            extra_args="--user {{ ansible_user }}"
 
-    # On OS X, we need to create the destination directory before the copy
-    # module will succeed.
     - name: create HTTP replay directory
       tags: ndt-e2e
       file: path={{ http_replay_dir }}


### PR DESCRIPTION
The task to copy the replay file to the node was broken in that it set dest
to /opt/ndt-http-replays. We want the file to copy into:

/opt/ndt-http-replays/banjo-2016-05-10.replay

but instead it was geting copied as a file named:

/opt/ndt-http-replays

This creates the parent directory ahead of time so that the file is copied as
expected.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-ansible/15)

<!-- Reviewable:end -->
