### PR TITLE
Adding an explicit protocol for NDT HTML5 URL

### DIFF
--- a/hosts
+++ b/hosts
@@ -24,7 +24,7 @@ mlab-mac-capitan
 [all:vars]
 http_proxy=http://172.16.1.1:8080
 ndt_server_fqdn=ndt.iupui.mlab2.iad0t.measurement-lab.org
-ndt_server_url="{{ ndt_server_fqdn }}:7123/"
+ndt_server_url=http://{{ ndt_server_fqdn }}:7123/
 # Note: The username and password are *not* secret and are safe to publish. The
 # credentials are not useful unless the user already has access to the testbed,
 # and there are no trust boundaries within the testbed itself.


### PR DESCRIPTION
It turns out that Microsoft Edge will not automatically deduce the http: part
so we'll add it explicitly.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-ansible/16)

<!-- Reviewable:end -->
