### PR TITLE
Fixes a few bugs related to result packaging

### DIFF
--- a/run.yml
+++ b/run.yml
@@ -159,13 +159,9 @@
   tags: gather
   tasks:
     - name: zip results and logs
-      raw: Compress-Archive -Path {{ item }}\\* -Update -DestinationPath {{ archive_path }}
-      with_items:
-        - "{{ raw_results_dir }}"
-        - "{{ results_log_dir }}"
-
-    - name: move all result and log files to an archive folder of already packaged files
-      raw: "Move-Item {{ item }}\\* {{ archived_results_dir }}"
+      raw: Compress-Archive -Path {{ item }}\* -Update -DestinationPath {{ archive_path }}
+      register: zip_result
+      failed_when: "'Error' in zip_result.stderr"
       with_items:
         - "{{ raw_results_dir }}"
         - "{{ results_log_dir }}"
@@ -182,12 +178,6 @@
         - "{{ raw_results_dir }}"
         - "{{ results_log_dir }}"
 
-    - name: move all result and log files to an archive folder of already packaged files
-      shell: mv {{ item }}/* {{ archived_results_dir }}
-      with_items:
-        - "{{ raw_results_dir }}"
-        - "{{ results_log_dir }}"
-
 - name: Fetch NDT E2E results and copy them locally
   hosts: all
   tags: gather
@@ -197,3 +187,25 @@
              dest={{ local_archive_dir }}/{{ archive_file }}
              flat=yes
              fail_on_missing=yes
+
+- name: Archive NDT E2E results on Windows hosts
+  hosts: windows
+  tags: gather
+  tasks:
+    - name: move all result and log files to an archive folder of already packaged files
+      raw: "Move-Item {{ item }}\\* {{ archived_results_dir }} -Force"
+      with_items:
+        - "{{ raw_results_dir }}"
+        - "{{ results_log_dir }}"
+
+- name: Archive NDT E2E results on Linux/OS X hosts
+  hosts:
+    - linux
+    - osx
+  tags: gather
+  tasks:
+    - name: move all result and log files to an archive folder of already packaged files
+      shell: mv {{ item }}/* {{ archived_results_dir }}
+      with_items:
+        - "{{ raw_results_dir }}"
+        - "{{ results_log_dir }}"


### PR DESCRIPTION
- Moves the archiving of results to after we've successfully scraped them.
  It's more important that we successfully scrape results than successfully
  archive them.
- Adds the -Force parameter to the Move-Item call so that moving files to the
  archive folder overwrites any existing files with the same filename (for
  consistency with Linux / OS X implementation.
- Adds a failed_when property to the Compress-Archive task because otherwise
  Ansible will consider a Compress-Archive call that fails to add all items
  as a success.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-ansible/19)

<!-- Reviewable:end -->
