### PR TITLE
Removing variables/tasks related to mitmproxy

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -3,7 +3,7 @@ local_http_replay_dir: http_replays
 
 # HTTP replay file for Banjo client (note that this file is not in this git
 # repo and must be generated or copied by an alternative means).
-http_replay_file: banjo-2016-05-10.replay
+http_replay_file: replay-banjo-2016-06-03.yaml
 
 # Git URL for NDT E2E Client Worker.
 ndt_e2e_client_git: https://github.com/m-lab/ndt-e2e-clientworker.git

--- a/group_vars/osx
+++ b/group_vars/osx
@@ -13,6 +13,3 @@ raw_results_dir: "{{ results_dir }}/raw"
 zipped_results_dir: "{{ results_dir }}/zips"
 archived_results_dir: "{{ results_dir }}/archived"
 results_log_dir: "{{ results_dir }}/logs"
-
-# Install directory for mitmproxy utility.
-mitmproxy_install_dir: /opt/mitmproxy

--- a/prepare.yml
+++ b/prepare.yml
@@ -196,14 +196,6 @@
         http_proxy: "{{ http_proxy }}"
       raw: pip install -r "{{ ndt_e2e_client_dir }}\\requirements.txt"
 
-    # TODO(mtlynch): Figure out why this works locally but not remotely
-    - name: install mitmdump (part of mitmproxy)
-      tags: ndt-e2e
-      environment:
-        http_proxy: "{{ http_proxy }}"
-        https_proxy: "{{ http_proxy }}"
-      raw: pip install mitmproxy
-
     - name: create HTTP replay directory
       tags: ndt-e2e
       win_file: "path={{ http_replay_dir }} state=directory"
@@ -271,14 +263,6 @@
         - unzip
         - xvfb
         - zip
-        # Required for mitmproxy
-        - python-dev
-        - libffi-dev
-        - libssl-dev
-        - libxml2-dev
-        - libxslt1-dev
-        - libjpeg8-dev
-        - zlib1g-dev
 
     - name: install xvfb init.d daemon script
       tags: xvfb
@@ -316,10 +300,6 @@
     - name: Install ndt e2e requirements
       tags: ndt-e2e
       pip: requirements={{ ndt_e2e_client_dir }}/requirements.txt
-
-    - name: Install mitmproxy
-      tags: ndt-e2e
-      pip: name=mitmproxy
 
     - name: create HTTP replay directory
       tags: ndt-e2e
@@ -360,10 +340,6 @@
     git_installer_url: http://ufpr.dl.sourceforge.net/project/git-osx-installer/{{ git_installer_version }}.dmg
     git_installer_download_path: "{{ temp_dir }}/{{ git_installer_version }}.dmg"
     git_installer_image_name: /Volumes/Git 2.8.1 Mavericks Intel Universal
-
-    mitmproxy_version: 0.17.1
-    mitmproxy_url: https://github.com/mitmproxy/mitmproxy/releases/download/v{{ mitmproxy_version }}/mitmproxy-{{ mitmproxy_version }}-osx.tar.gz
-    mitmproxy_download_path: "{{ temp_dir }}/mitmproxy-{{ mitmproxy_version }}.tar.gz"
   become: True
   become_method: sudo
   become_user: root
@@ -415,26 +391,6 @@
 
     - name: unmount Git installer dmg file
       shell: hdiutil detach "{{ git_installer_image_name }}/"
-
-    - name: download mitmproxy
-      become_user: "{{ ansible_user }}"
-      tags: mitmproxy
-      get_url: url={{ mitmproxy_url }} dest={{ mitmproxy_download_path }}
-      register: mitmproxy_download
-
-    - name: create mitmproxy directory
-      tags: mitmproxy
-      file: path={{ mitmproxy_install_dir }}
-            state=directory
-            owner={{ ansible_user }}
-
-    # TODO(mtlynch): Switch to unarchive module once issue #15754 is fixed:
-    # https://github.com/ansible/ansible/issues/15754
-    - name: unarchive mitmproxy
-      become_user: "{{ ansible_user }}"
-      tags: mitmproxy
-      shell: tar -xvzf {{ mitmproxy_download_path }} -C {{ mitmproxy_install_dir }}
-      when: mitmproxy_download.changed
 
     - name: install pip
       tags: pip

--- a/run.yml
+++ b/run.yml
@@ -81,7 +81,7 @@
     - name: set environment variables
       set_fact:
         environment_vars:
-          PATH: "{{ ansible_env.PATH }}:{{ selenium_drivers_path }}:{{ mitmproxy_install_dir }}"
+          PATH: "{{ ansible_env.PATH }}:{{ selenium_drivers_path }}"
 
 # It is currently not possible to use the same play for all hosts:
 #  * The shell and command modules are unavailable on Windows.


### PR DESCRIPTION
As of ab478ec in ndt-e2e-clientworker, mitmproxy is no longer required by the
client wrapper, so we're removing all tasks related to installing mitmproxy on
the client worker hosts.

Also updates the http_replay_file to refer to the latest YAML-based banjo
replay file.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-ansible/21)

<!-- Reviewable:end -->
