### PR TITLE
Adding a play to configure ethtool on lockjaw

### DIFF
--- a/configure_control.yml
+++ b/configure_control.yml
@@ -12,6 +12,7 @@
         dest: /etc/hosts
         marker: "# {mark} ANSIBLE MANAGED BLOCK - M-Lab Testbed"
         block: |
+          172.16.1.1         lockjaw
           172.16.1.27        mlab-linux-mini
           172.16.1.28        mlab-mac-mountainlion
           172.16.1.29        mlab-mac-yosemite

--- a/hosts
+++ b/hosts
@@ -1,4 +1,8 @@
+# Tested router
+lockjaw ansible_user=root
+
 # Testbed Middlebox
+[mlabmeddlebox]
 mlabmeddlebox
 
 [windows]
@@ -34,7 +38,13 @@ http_proxy=http://172.16.1.1:8080
 ndt_server_fqdn=ndt.iupui.mlab2.iad0t.measurement-lab.org
 ndt_server_url=http://{{ ndt_server_fqdn }}:7123/
 
-[all:vars]
+# All nodes internal to the testbed (excludes lockjaw, which is
+# Internet-facing).
+[internal:children]
+clients
+mlabmeddlebox
+
+[internal:vars]
 # Note: The username and password are *not* secret and are safe to publish. The
 # credentials are not useful unless the user already has access to the testbed,
 # and there are no trust boundaries within the testbed itself.

--- a/hosts
+++ b/hosts
@@ -1,4 +1,5 @@
 # Testbed router
+[lockjaw]
 lockjaw ansible_user=root
 
 # Testbed Middlebox

--- a/hosts
+++ b/hosts
@@ -1,4 +1,4 @@
-# Tested router
+# Testbed router
 lockjaw ansible_user=root
 
 # Testbed Middlebox

--- a/prepare.yml
+++ b/prepare.yml
@@ -1,6 +1,12 @@
 ---
 # vim:ft=ansible:
 
+- name: Configure lockjaw for testing
+  hosts: lockjaw
+  tasks:
+    - name: Ensure NIC is configured for its maximum speed (1 Gbps)
+      shell: ethtool -s eth5 speed 1000 duplex full
+
 - name: Install NDT client wrapper and all dependencies on Windows client machines
   hosts: windows
   vars:


### PR DESCRIPTION
We ran into an issue last round of performance testing because ethtool had
been used to configure the NIC to 100 Mbps during previous testing. This adds
a play in the prepare playbook to ensure that the NIC is always set to its
maximum capacity (1 Gbps).

Note that we do this in `prepare.yml` instead of `run.yml` because lockjaw is internet-facing and therefore requires SSH authentication. If we put it in `run.yml` adjacent to the meddlebox settings (probably the more intuitive place), the operator would have to enter their SSH passphrase partway through playbook execution on every run of `run.yml`.

This fixes #24.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-ansible/25)

<!-- Reviewable:end -->
