### PR TITLE
Fix missing flag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ control machine for the NDT E2E testing playbooks so that you can manage the
 M-Lab NDT testbed, run the following command from your local machine:
 
 ```bash
-ansible-playbook configure_control.yml
+ansible-playbook configure_control.yml --ask-sudo-pass
 ```
 
 ### Provisioning client worker nodes


### PR DESCRIPTION
Previously, this command worked if you had recently run a sudo command, but
would fail if you hadn't. This fixes it to explicitly ask for a password when
it needs to run via sudo.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-ansible/26)

<!-- Reviewable:end -->
