### PR TITLE
Updating calling semantics for client wrapper

### DIFF
--- a/hosts
+++ b/hosts
@@ -37,7 +37,6 @@ osx
 [clients:vars]
 http_proxy=http://172.16.1.1:8080
 ndt_server_fqdn=ndt.iupui.mlab2.iad0t.measurement-lab.org
-ndt_server_url=http://{{ ndt_server_fqdn }}:7123/
 
 # All nodes internal to the testbed (excludes lockjaw, which is
 # Internet-facing).

--- a/run.yml
+++ b/run.yml
@@ -128,7 +128,7 @@
         --verbose
         --client=ndt_js
         --browser={{ item }}
-        --client_url={{ ndt_server_url }}
+        --server={{ ndt_server_fqdn }}
         --output={{ raw_results_dir }}
         --iterations={{ iterations }} `>`> {{ log_path }} 2`>`&1
       with_items: "{{ supported_browsers }}"
@@ -160,7 +160,7 @@
         --verbose
         --client=ndt_js
         --browser={{ item }}
-        --client_url={{ ndt_server_url }}
+        --server={{ ndt_server_fqdn }}
         --output={{ raw_results_dir }}
         --iterations={{ iterations }} 2>&1 | tee -a {{ log_path }}
       with_items: "{{ supported_browsers }}"


### PR DESCRIPTION
Updating the command parameters for client wrapper to eliminate the
--client_url parameter.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-ansible/27)

<!-- Reviewable:end -->
