### PR TITLE
Implements changes necessary to test Safari in E2E testing

### DIFF
--- a/group_vars/osx
+++ b/group_vars/osx
@@ -7,6 +7,9 @@ ndt_e2e_client_dir: /opt/ndt-e2e-clientworker
 # Path for selenium extension binaries
 selenium_drivers_path: /opt/selenium_drivers
 
+# File name of Selenium server JAR file
+selenium_server_jar_file: selenium-server-standalone-2.53.1.jar
+
 # Directories for storing results of NDT E2E tests.
 results_dir: /opt/ndt-results
 raw_results_dir: "{{ results_dir }}/raw"

--- a/hosts
+++ b/hosts
@@ -35,7 +35,7 @@ linux
 osx
 
 [clients:vars]
-http_proxy=http://172.16.1.1:8080
+http_proxy=http://lockjaw.client.mlab.lan:8080
 ndt_server_fqdn=ndt.iupui.mlab2.iad0t.measurement-lab.org
 
 # All nodes internal to the testbed (excludes lockjaw, which is

--- a/prepare.yml
+++ b/prepare.yml
@@ -340,12 +340,21 @@
     selenium_safari_driver_url: http://selenium-release.storage.googleapis.com/2.48/SafariDriver.safariextz
     selenium_safari_download_path: "{{ temp_dir }}/SafariDriver.safariextz"
 
+    selenium_server_jar_url: "http://selenium-release.storage.googleapis.com/2.53/{{ selenium_server_jar_file }}"
+    selenium_server_jar_path: "{{ selenium_drivers_path }}/{{ selenium_server_jar_file }}"
+
     # Named mavericks, but works on El Capitan.
     # TODO(mtlynch): Verify this package works on Mountain Lion.
     git_installer_version: git-2.8.1-intel-universal-mavericks
     git_installer_url: http://ufpr.dl.sourceforge.net/project/git-osx-installer/{{ git_installer_version }}.dmg
     git_installer_download_path: "{{ temp_dir }}/{{ git_installer_version }}.dmg"
     git_installer_image_name: /Volumes/Git 2.8.1 Mavericks Intel Universal
+
+    jdk_installer_version: jdk-8u121-macosx-x64
+    jdk_installer_url: "http://mirror.measurementlab.net/misc/{{ jdk_installer_version }}.dmg"
+    jdk_installer_download_path: "{{ temp_dir }}/{{ jdk_installer_version }}.dmg"
+    jdk_installer_image_name: JDK 8 Update 121
+
   become: True
   become_method: sudo
   become_user: root
@@ -366,6 +375,13 @@
       get_url: url={{ selenium_chrome_driver_url }}
                dest={{ selenium_chrome_download_path }}
       register: download_selenium_chrome
+
+    - name: download Selenium server jar
+      become_user: "{{ ansible_user }}"
+      tags: selenium-jar
+      get_url: url={{ selenium_server_jar_url }}
+               dest={{ selenium_server_jar_path }}
+      register: download_selenium_jar
 
     # TODO(mtlynch): Switch to unarchive module once issue #15754 is fixed:
     # https://github.com/ansible/ansible/issues/15754
@@ -397,6 +413,20 @@
 
     - name: unmount Git installer dmg file
       shell: hdiutil detach "{{ git_installer_image_name }}/"
+
+    - name: download JDK installer for OS X
+      become_user: "{{ ansible_user }}"
+      get_url: url={{ jdk_installer_url }}
+               dest={{ jdk_installer_download_path }}
+
+    - name: mount JDK installer dmg file
+      shell: hdiutil attach {{ jdk_installer_download_path }}
+
+    - name: install JDK
+      shell: installer -package "/Volumes/{{ jdk_installer_image_name }}/{{ jdk_installer_image_name }}.pkg" -target /
+
+    - name: unmount JDK installer dmg file
+      shell: hdiutil detach "/Volumes/{{ jdk_installer_image_name }}/"
 
     - name: install pip
       tags: pip

--- a/run.yml
+++ b/run.yml
@@ -76,13 +76,13 @@
         supported_browsers:
           - firefox
           - chrome
-          # TODO(mtlynch): Uncomment when Safari automation is fixed.
-          # - safari
+          - safari
 
     - name: set environment variables
       set_fact:
         environment_vars:
           PATH: "{{ ansible_env.PATH }}:{{ selenium_drivers_path }}"
+          SELENIUM_SERVER_JAR: "{{ selenium_drivers_path }}/{{ selenium_server_jar_file }}"
 
 - name: Configure meddlebox for testing
   hosts: mlabmeddlebox


### PR DESCRIPTION
Up to now we have not been doing Safari testing when running E2E tests. I _believe_ this is because [there was an issue](https://github.com/m-lab/ndt-e2e-ansible/blob/master/prepare.yml#L384) [automating the installation](https://github.com/m-lab/ndt-e2e-ansible/blob/master/run.yml#L79
) of the necessary drivers.

However, it turns out that the client_wrapper *does* support Safari. This PR implements the necessary changes to start testing Safari on the MacOS clients.

**NOTE**: `prepare.yml` has been downloading `SafariDriver.safariextz`, which is a Safari extension. Part of the issue before was that this extension could not be installed via automation. I had Chris install it manually in Safari on the Capitan client, which is the client we use regularly for E2E testing. What is currently unclear to me (I haven't tested it) is whether this extension is actually necessary. Part of the fix in this PR is to download a JAR file with a standalone version of Selenium, then set an environment variable to point to this JAR file.  Some reading about makes me believe that installation of `SafariDriver.safariextz` is a newer way of handling Safari testing than using the JAR file. However, there is a possibility that they are complementary. If they are complementary, then this means that Safari testing is not 100% automated in that someone would need to manually install the extension into Safari on the client we use in the testbed. We should probably do some testing to see what happens if we remove the extension from Safari.