### PR TITLE
Changes default ndt_server_fqdn value to use SSL-frienly FQDN

### DIFF
--- a/hosts
+++ b/hosts
@@ -36,7 +36,8 @@ osx
 
 [clients:vars]
 http_proxy=http://lockjaw.client.mlab.lan:8080
-ndt_server_fqdn=ndt.iupui.mlab2.iad0t.measurement-lab.org
+# Be sure to use the SSL-friendly FQDN (with hyphens instead of dots)
+ndt_server_fqdn=ndt-iupui-mlab2-iad0t.measurement-lab.org
 
 # All nodes internal to the testbed (excludes lockjaw, which is
 # Internet-facing).


### PR DESCRIPTION
Previously, the `ndt_server_fqdn` variable in the `hosts` file used the normal dotted version of the FQDN for the NDT host to test against. This was causing breakage on certain browsers when testing the OneBox client. The OneBox client was defaulting to using HTTPS, but SSL certificate validating was failing with the dotted address, and hence the test failed. This PR simply changes the default value of that variable to use the SSL-friendly FQDN (with dashes instead of dots), and adds a comment reminding the user to only use these SSL-friendly names.