### PR TITLE
Changes references of MacOS Capitan to Sierra, and updates Firefox d/l URL for Win

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ This is a more advanced example. It runs:
 * 50 test iterations
 * excluding the Banjo client
 * only under the Chrome browser
-* on the mlab-mac-capitan remote node
+* on the mlab-mac-sierra remote node
 
 ```bash
 ansible-playbook run.yml \
-  --limit mlab-mac-capitan:mlabmeddlebox \
+  --limit mlab-mac-sierra:mlabmeddlebox \
   --extra-vars "supported_browsers=chrome iterations=50" \
   --skip-tags "banjo"
 ```

--- a/configure_control.yml
+++ b/configure_control.yml
@@ -16,7 +16,7 @@
           172.16.1.27        mlab-linux-mini
           172.16.1.28        mlab-mac-mountainlion
           172.16.1.29        mlab-mac-yosemite
-          172.16.1.30        mlab-mac-capitan
+          172.16.1.30        mlab-mac-sierra
           172.16.1.31        mlab-win7
           172.16.1.32        mlab-win8
           172.16.1.33        mlab-win10

--- a/hosts
+++ b/hosts
@@ -24,7 +24,7 @@ ansible_winrm_server_cert_validation=ignore
 mlab-linux-mini
 
 [osx]
-mlab-mac-capitan
+mlab-mac-sierra
 # Not yet in active use.
 #mlab-mac-yosemite
 #mlab-mac-mountainlion

--- a/prepare.yml
+++ b/prepare.yml
@@ -28,8 +28,8 @@
       dest: "{{ temp_dir }}\\chrome_installer.exe"
 
     firefox_installer:
-      url: https://download.mozilla.org/?product=firefox-45.0.1-SSL&os=win&lang=en-US
-      dest: "{{ temp_dir }}\\Firefox Setup 45.0.1.exe"
+      url: https://download.mozilla.org/?product=firefox-stub&os=win&lang=en-US
+      dest: "{{ temp_dir }}\\Firefox Setup.exe"
 
     selenium_edge_installer:
       # WebDriver installer for Windows 10 Build 10240
@@ -343,7 +343,7 @@
     selenium_server_jar_url: "http://selenium-release.storage.googleapis.com/2.53/{{ selenium_server_jar_file }}"
     selenium_server_jar_path: "{{ selenium_drivers_path }}/{{ selenium_server_jar_file }}"
 
-    # Named mavericks, but works on El Capitan.
+    # Named mavericks, but works on Sierra (hopefully).
     # TODO(mtlynch): Verify this package works on Mountain Lion.
     git_installer_version: git-2.8.1-intel-universal-mavericks
     git_installer_url: http://ufpr.dl.sourceforge.net/project/git-osx-installer/{{ git_installer_version }}.dmg


### PR DESCRIPTION
Up to now, testbed clients have been locked down with the OS and browser version from when the testbed was first deployed. This meant that the testbed was not keeping pace with what most people would be using on their own machines, and so wouldn't be representative of Internet traffic to M-Lab. 

It was decided that we should be running more modern software on the testbed clients, both OS and browser, and that in the future we should continue to do upgrades.

This PR:

* Changes the download URL for Firefox for Windows to one that should always return the latest version of Firefox.

* Changes any references to MacOS Capitan to MacOS Sierra (since that client was upgraded).

NOTE: Even though we upgraded the Ubuntu client from 14.04 to 16.04, we don't need to do any sort of naming changes because the Linux client is generically known as mlab-mini-linux. And for Windows, we are still just using Windows 10.