### PR TITLE
Updates WebDriver drivers and removes all references to JAR files

### DIFF
--- a/group_vars/osx
+++ b/group_vars/osx
@@ -7,9 +7,6 @@ ndt_e2e_client_dir: /opt/ndt-e2e-clientworker
 # Path for selenium extension binaries
 selenium_drivers_path: /opt/selenium_drivers
 
-# File name of Selenium server JAR file
-selenium_server_jar_file: selenium-server-standalone-2.53.1.jar
-
 # Directories for storing results of NDT E2E tests.
 results_dir: /opt/ndt-results
 raw_results_dir: "{{ results_dir }}/raw"

--- a/prepare.yml
+++ b/prepare.yml
@@ -367,14 +367,11 @@
     # Temporary directory in which we download packages.
     temp_dir: /tmp
 
-    selenium_chrome_driver_url: https://chromedriver.storage.googleapis.com/2.27/chromedriver_mac64.zip
+    selenium_chrome_driver_url: https://chromedriver.storage.googleapis.com/2.29/chromedriver_mac64.zip
     selenium_chrome_download_path: "{{ temp_dir }}/chromedriver_mac64.zip"
 
     selenium_gecko_driver_url: https://github.com/mozilla/geckodriver/releases/download/v0.15.0/geckodriver-v0.15.0-macos.tar.gz
     selenium_gecko_download_path: "{{ temp_dir }}/geckodriver_macos.tar.gz"
-
-    selenium_server_jar_url: "http://selenium-release.storage.googleapis.com/2.53/{{ selenium_server_jar_file }}"
-    selenium_server_jar_path: "{{ selenium_drivers_path }}/{{ selenium_server_jar_file }}"
 
     # Named mavericks, but works on Sierra (hopefully).
     # TODO(mtlynch): Verify this package works on Mountain Lion.
@@ -382,11 +379,6 @@
     git_installer_url: http://ufpr.dl.sourceforge.net/project/git-osx-installer/{{ git_installer_version }}.dmg
     git_installer_download_path: "{{ temp_dir }}/{{ git_installer_version }}.dmg"
     git_installer_image_name: /Volumes/Git 2.10.1 Mavericks Intel Universal
-
-    jdk_installer_version: jdk-8u121-macosx-x64
-    jdk_installer_url: "http://mirror.measurementlab.net/misc/{{ jdk_installer_version }}.dmg"
-    jdk_installer_download_path: "{{ temp_dir }}/{{ jdk_installer_version }}.dmg"
-    jdk_installer_image_name: JDK 8 Update 121
 
   become: True
   become_method: sudo
@@ -448,20 +440,6 @@
 
     - name: unmount Git installer dmg file
       shell: hdiutil detach "{{ git_installer_image_name }}/"
-
-    - name: download JDK installer for OS X
-      become_user: "{{ ansible_user }}"
-      get_url: url={{ jdk_installer_url }}
-               dest={{ jdk_installer_download_path }}
-
-    - name: mount JDK installer dmg file
-      shell: hdiutil attach {{ jdk_installer_download_path }}
-
-    - name: install JDK
-      shell: installer -package "/Volumes/{{ jdk_installer_image_name }}/{{ jdk_installer_image_name }}.pkg" -target /
-
-    - name: unmount JDK installer dmg file
-      shell: hdiutil detach "/Volumes/{{ jdk_installer_image_name }}/"
 
     - name: install pip
       tags: pip

--- a/prepare.yml
+++ b/prepare.yml
@@ -37,7 +37,7 @@
       dest: "{{ temp_dir }}\\MicrosoftWebDriver.msi"
 
     selenium_chrome_driver_zip:
-      url: https://chromedriver.storage.googleapis.com/2.27/chromedriver_win32.zip
+      url: https://chromedriver.storage.googleapis.com/2.29/chromedriver_win32.zip
       dest: "{{ temp_dir }}\\chromedriver_win32.zip"
 
     selenium_gecko_driver_zip:

--- a/prepare.yml
+++ b/prepare.yml
@@ -260,7 +260,7 @@
 - name: Install NDT client wrapper and all dependencies on Linux client machines
   hosts: linux
   vars:
-    selenium_chrome_driver_url: http://chromedriver.storage.googleapis.com/2.21/chromedriver_linux64.zip
+    selenium_chrome_driver_url: http://chromedriver.storage.googleapis.com/2.29/chromedriver_linux64.zip
     selenium_chrome_driver: "{{ selenium_drivers_path }}/chromedriver"
     selenium_gecko_driver_url: https://github.com/mozilla/geckodriver/releases/download/v0.15.0/geckodriver-v0.15.0-linux64.tar.gz
     selenium_gecko_driver: "{{ selenium_drivers_path }}/geckodriver"

--- a/run.yml
+++ b/run.yml
@@ -82,7 +82,6 @@
       set_fact:
         environment_vars:
           PATH: "{{ ansible_env.PATH }}:{{ selenium_drivers_path }}"
-          SELENIUM_SERVER_JAR: "{{ selenium_drivers_path }}/{{ selenium_server_jar_file }}"
 
 - name: Configure meddlebox for testing
   hosts: mlabmeddlebox
@@ -169,9 +168,6 @@
     - name: run html5 client wrapper for OS X
       tags: html5
       environment: "{{ environment_vars }}"
-      become: True
-      become_method: sudo
-      become_user: root
       shell: >
         python {{ ndt_e2e_client_dir }}/{{ client_wrapper_path }}
         --verbose
@@ -201,9 +197,6 @@
     - name: run banjo wrapper for OS X
       tags: banjo
       environment: "{{ environment_vars }}"
-      become: True
-      become_method: sudo
-      become_user: root
       shell: >
         python {{ ndt_e2e_client_dir }}/{{ client_wrapper_path }}
         --verbose


### PR DESCRIPTION
This PR contains a few straggler updates to get things working with E2E testing on the updated clients and browsers in the testbed. Sorry for the poorly named "more-updates" branch. I apparently named the branch is an uninspired moment.

* We want to be running the latest version of the various WebDrivers, since in many cases testing simply won't work without it.

* Removes all remaining references to the Selenium standalone JAR file, and also removes JDK prepare tasks on the OSX Sierra client, since JDK was only installed to be able to use the JAR, which we are no longer using.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-ansible/39)
<!-- Reviewable:end -->
